### PR TITLE
功能：添加手动知识管理的API端点

### DIFF
--- a/munchkin/apps/knowledge_mgmt/serializers.py
+++ b/munchkin/apps/knowledge_mgmt/serializers.py
@@ -1,0 +1,9 @@
+from rest_framework import serializers
+
+from apps.knowledge_mgmt.models import ManualKnowledge
+
+
+class ManualKnowledgeSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ManualKnowledge
+        fields = '__all__'

--- a/munchkin/apps/knowledge_mgmt/urls.py
+++ b/munchkin/apps/knowledge_mgmt/urls.py
@@ -1,8 +1,10 @@
 from rest_framework import routers
 
 from apps.knowledge_mgmt.views.knowledge_search_viewset import KnowledgeSearchViewSet
+from apps.knowledge_mgmt.views.manual_knowledge_view import ManualKnowledgeSet
 
 router = routers.DefaultRouter()
+router.register(r'api/manual_knowledge', ManualKnowledgeSet)
 router.register(r"api/knowledge_search", KnowledgeSearchViewSet, basename="knowledge_search")
 urlpatterns = router.urls
 

--- a/munchkin/apps/knowledge_mgmt/views/manual_knowledge_view.py
+++ b/munchkin/apps/knowledge_mgmt/views/manual_knowledge_view.py
@@ -1,0 +1,9 @@
+from rest_framework.viewsets import ModelViewSet
+
+from apps.knowledge_mgmt.models import ManualKnowledge
+from apps.knowledge_mgmt.serializers import ManualKnowledgeSerializer
+
+
+class ManualKnowledgeSet(ModelViewSet):
+    serializer_class = ManualKnowledgeSerializer
+    queryset = ManualKnowledge.objects.all()


### PR DESCRIPTION
- 添加了一个新文件 `munchkin/apps/knowledge_mgmt/serializers.py`
- 添加了一个新文件 `munchkin/apps/knowledge_mgmt/views/manual_knowledge_view.py`
- 修改了 `munchkin/apps/knowledge_mgmt/urls.py`，包括新的API路由，用于 `ManualKnowledgeSet` 视图