### PR TITLE
特性：重构管理员文件以设置对象的所有者

### DIFF
--- a/munchkin/apps/core/admin/OwnerAdminBase.py
+++ b/munchkin/apps/core/admin/OwnerAdminBase.py
@@ -1,0 +1,17 @@
+from unfold.admin import ModelAdmin
+from django.contrib.auth.models import User
+
+
+class OwnerAdminBase(ModelAdmin):
+    def save_model(self, request, obj, form, change):
+        # 检查 obj 是否有 owner 字段，并且该字段的类型是 User
+        if hasattr(obj, 'owner') and obj._meta.get_field('owner').remote_field.model == User:
+            # 把当前请求的用户设置为 owner
+            obj.owner = request.user
+        obj.save()
+        # ModelAdmin 本身的逻辑
+        for action in self.get_actions_submit_line(request):
+            if action.action_name not in request.POST:
+                continue
+
+            action.method(request, obj)

--- a/munchkin/apps/core/admin/guarded_admin_base.py
+++ b/munchkin/apps/core/admin/guarded_admin_base.py
@@ -5,10 +5,10 @@ from guardian.shortcuts import (
     get_objects_for_user,
     assign_perm,
 )
-from unfold.admin import ModelAdmin
+from apps.core.admin.OwnerAdminBase import OwnerAdminBase
 
 
-class GuardedAdminBase(ModelAdmin, GuardedModelAdmin):
+class GuardedAdminBase(OwnerAdminBase, GuardedModelAdmin):
 
     # app是否在主页面中显示的话由该函数决定
 


### PR DESCRIPTION
- 在 `munchkin/apps/core/admin` 目录下添加新文件 `OwnerAdminBase.py`
- 在 `OwnerAdminBase.py` 中的 `OwnerAdminBase` 类中添加 `save_model` 方法
- 在 `save_model` 方法中检查 `obj` 是否具有 `owner` 字段，以及字段类型是否为 `User`
- 在 `save_model` 方法中将当前用户设置为 `obj` 的所有者
- 在 `save_model` 方法中保存 `obj`
- 在 `OwnerAdminBase.py` 的 `get_actions_submit_line` 方法中循环遍历操作
- 如果请求的 POST 数据中存在操作名称，则执行相应的操作方法
- 修改 `guarded_admin_base.py`
- 从 `munchkin/apps/core/admin/OwnerAdminBase.py` 导入 `OwnerAdminBase`
- 在 `guarded_admin_base.py` 中将 `GuardedAdminBase` 的父类修改为 `OwnerAdminBase`

请记住将所有给出的 git commit 信息进行翻译。